### PR TITLE
Fix: Initialize max_hit_dice and hit_dice in Character class

### DIFF
--- a/shopkeeperPython/app.py
+++ b/shopkeeperPython/app.py
@@ -14,7 +14,6 @@ player_char.roll_stats() # Or set fixed stats for predictability
 player_char.stats = {"STR": 10, "DEX": 10, "CON": 10, "INT": 10, "WIS": 10, "CHA": 14} # Example
 player_char.base_max_hp = 10 + player_char._calculate_modifier(player_char.stats["CON"],is_base_stat_score=True) * player_char.level
 player_char.hp = player_char.get_effective_max_hp()
-player_char.hit_dice = player_char.max_hit_dice
 # player_char.gold = 250 # Example starting gold for the character
 
 game_manager_instance = GameManager(player_character=player_char, output_stream=output_stream)

--- a/shopkeeperPython/game/character.py
+++ b/shopkeeperPython/game/character.py
@@ -33,6 +33,8 @@ class Character:
         self.stat_bonuses = {stat: 0 for stat in self.STAT_NAMES}
         self.ac_bonus = 0
         self.level = 1
+        self.max_hit_dice = self.level # Character starts at level 1
+        self.hit_dice = self.max_hit_dice # Starts with all hit dice available
         self.xp = 0
         self.pending_xp = 0
         self.base_max_hp = 0
@@ -127,6 +129,8 @@ class Character:
         while self.xp >= next_level_threshold_xp:
             self.level += 1
             print(f"{self.name} leveled up to Level {self.level}!")
+            self.max_hit_dice = self.level
+            self.hit_dice = min(self.hit_dice + 1, self.max_hit_dice) # Gain 1 HD, cap at new max
             con_modifier = self._calculate_modifier(self.stats["CON"], is_base_stat_score=True)
 
             print(f"{self.name} has {self.skill_points_to_allocate} skill point(s) to allocate.")


### PR DESCRIPTION
The AttributeError `Character object has no attribute 'max_hit_dice'` occurred in `app.py` because `max_hit_dice` was accessed before it was assigned.

This commit addresses the issue by:
1. Initializing `max_hit_dice` and `hit_dice` in the `Character` class's `__init__` method. `max_hit_dice` is set to `self.level` (initially 1), and `hit_dice` is set to `self.max_hit_dice`.
2. Ensuring `max_hit_dice` is updated to the new level and `hit_dice` is incremented by 1 (and capped at the new max) when a character levels up in the `_check_level_up` method.
3. Removing the redundant assignment `player_char.hit_dice = player_char.max_hit_dice` from `app.py` as this is now handled by the Character constructor.
4. Verifying that de-leveling logic in `award_xp` and `_check_level_up` correctly updates `max_hit_dice` and caps `hit_dice`.

These changes ensure that `max_hit_dice` and `hit_dice` are consistently managed throughout the character's lifecycle.