### PR TITLE
Refactor: Implement tabbed interface for Actions & Log

### DIFF
--- a/shopkeeperPython/static/style.css
+++ b/shopkeeperPython/static/style.css
@@ -122,16 +122,46 @@ body {
     border-left: 1px solid #999; /* Add separator */
 }
 
+/* New styles for Actions/Log Tabs */
+.actions-log-tab-buttons {
+    display: flex;
+    flex-shrink: 0; /* Prevent shrinking if content below is too large */
+}
+
+#actions-tab-button, #log-tab-button {
+    flex-grow: 1; /* Each button takes equal width */
+    padding: 8px 5px; /* Adjusted padding */
+    background-color: #b0b0b0; /* Slightly lighter than #actions-tab bg */
+    border-bottom: 1px solid #888; /* Separator from content */
+    text-align: center;
+    font-weight: bold;
+    font-size: 0.85em;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    border-right: 1px solid #888; /* Separator between buttons */
+}
+
+#log-tab-button {
+    border-right: none; /* No right border for the last button */
+}
+
+#actions-tab-button:hover, #log-tab-button:hover {
+    background-color: #a0a0a0;
+}
+
+.active-tab-button {
+    background-color: #f9f9f9 !important; /* Same as .tab-content bg for seamless look */
+    color: #333;
+    border-bottom: 1px solid #f9f9f9 !important; /* Make it look like it's part of the content area */
+}
+
 
 /* Common styles for all tab types (stats, info, inventory, actions) */
 #stats-tab, #info-tab, #inventory-tab, #actions-tab {
     /* Common properties already defined above or per specific ID */
 }
 
-.actions-tab-active .tab-title-bar { /* This is for JS interactivity, keep it */
-    background-color: #a8d5e2; /* Highlight color for active tab */
-    font-weight: bold;
-}
+/* REMOVE: .actions-tab-active .tab-title-bar - This is replaced by .active-tab-button */
 
 /* Settings Menu Button and Popup */
 #top-right-menu-button {
@@ -213,9 +243,7 @@ body {
     cursor: default; /* Default cursor for non-interactive titles */
 }
 
-#actions-tab .tab-title-bar {
-    cursor: pointer; /* Clickable title for actions tab */
-}
+/* REMOVE: #actions-tab .tab-title-bar - This element is gone */
 
 .tab-content {
     /* display: none; /* REMOVED for hover tabs. JS still hides #actions-content initially */
@@ -230,13 +258,43 @@ body {
 }
 
 /* Specifics for #actions-content (which also has .tab-content class) */
-/* This will be click-toggled, so it needs display:none initially */
 #actions-content {
-    display: none; /* Initially hidden, JS toggles to display:flex */
-    flex-direction: row; /* This is applied when JS makes it visible */
-    gap: 8px;
-    padding: 8px; /* Consistent padding */
+    display: block; /* Changed from none/flex, visibility now controlled by panels */
+    /* flex-direction: row; /* Not needed if panels stack vertically */
+    /* gap: 8px; /* Not needed if panels stack vertically */
+    /* padding: 8px; /* Padding will be on panels if needed, or keep if desired for overall content area */
+    height: calc(100% - 35px); /* Adjust based on tab button height, assuming buttons are around 35px */
+    overflow: hidden; /* To contain the sliding panels */
+    position: relative; /* For positioning panels if needed, though max-height should handle it */
 }
+
+#actions-panel-content, #log-panel-content {
+    width: 100%; /* Take full width of #actions-content */
+    height: 100%; /* Take full height of #actions-content when visible */
+    background-color: #f9f9f9; /* Match tab-content bg */
+    overflow: hidden; /* Important for max-height transition */
+    max-height: 0; /* Initially hidden */
+    transition: max-height 0.5s ease-in-out;
+    box-sizing: border-box; /* Include padding/border in height */
+}
+
+#actions-panel-content.panel-visible,
+#log-panel-content.panel-visible {
+    max-height: 15vh; /* Or a fixed value like 500px if vh is problematic. #actions-tab is 20vh. Needs to be enough for content. */
+    /* If content inside panels needs scrolling, add overflow-y: auto; here
+       and ensure #action-controls-wrapper and .log-box don't have fixed height:100%
+       if this parent has overflow-y: auto as well.
+       For now, assuming content fits or internal elements scroll.
+    */
+}
+
+/* Ensure the direct children of panels can fill the space */
+#actions-panel-content > #action-controls-wrapper,
+#log-panel-content > .log-box {
+    height: 100%; /* Fill the visible height of the panel */
+    overflow-y: auto; /* Allow scrolling within these if content exceeds panel height */
+}
+
 
 /* Add overflow:hidden to tab containers */
 #stats-tab, #info-tab, #inventory-tab {

--- a/shopkeeperPython/templates/index.html
+++ b/shopkeeperPython/templates/index.html
@@ -462,18 +462,31 @@
             </div>
         </div>
         <div id="actions-tab">
-            <div class="tab-title-bar">Actions & Log</div>
+            <div class="actions-log-tab-buttons">
+                <div id="actions-tab-button">Actions</div>
+                <div id="log-tab-button">Log</div>
+            </div>
             <div id="actions-content" class="tab-content">
-                <div class="log-box">
-                    <h2>Game Log</h2>
-                    <div id="game-output" style="white-space: pre-wrap; height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; background: #f9f9f9;">
-                        {{ game_output | safe }}
+                <div id="actions-panel-content">
+                    <div id="action-controls-wrapper">
+                        <form id="actionForm" action="{{ url_for('perform_action') }}" method="post">
+                            <input type="hidden" id="action_name_hidden" name="action_name" value="">
+                            <input type="hidden" id="action_details" name="action_details" value="{}">
                     </div>
                 </div>
-                <div id="action-controls-wrapper">
-                    <form id="actionForm" action="{{ url_for('perform_action') }}" method="post">
-                        <input type="hidden" id="action_name_hidden" name="action_name" value="">
-                        <input type="hidden" id="action_details" name="action_details" value="{}">
+                <div id="log-panel-content">
+                    <div class="log-box">
+                        <h2>Game Log</h2>
+                        <div id="game-output" style="white-space: pre-wrap; height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; background: #f9f9f9;">
+                            {{ game_output | safe }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div id="settings-popup" style="display: none;">
+            <ul>
+                <li id="settings-option">Settings</li>
                         <!-- Submit button might be dynamically added or made visible by JS,
                              or we can have a generic "Do Selected Action" button if an action is chosen.
                              For now, let action buttons themselves trigger form submission. -->
@@ -557,7 +570,6 @@
                         <button type="button" id="gatherResourcesButton" class="general-action-button">Gather Resources</button>
                         <!-- Add other general town/area actions here if needed -->
                     </div>
-
                 </div>
             </div>
         </div>
@@ -865,8 +877,14 @@
             const statsContent = document.getElementById('stats-content');
             const inventoryTab = document.getElementById('inventory-tab');
             const inventoryContent = document.getElementById('inventory-content');
-            const actionsTab = document.getElementById('actions-tab');
-            const actionsContent = document.getElementById('actions-content');
+            // const actionsTab = document.getElementById('actions-tab'); // Old reference
+            // const actionsContent = document.getElementById('actions-content'); // Old reference for direct toggle
+
+            // New elements for Actions/Log tabs
+            const actionsTabButton = document.getElementById('actions-tab-button');
+            const logTabButton = document.getElementById('log-tab-button');
+            const actionsPanelContent = document.getElementById('actions-panel-content');
+            const logPanelContent = document.getElementById('log-panel-content');
 
             const infoTab = document.getElementById('info-tab');
             const infoContent = document.getElementById('info-content');
@@ -879,25 +897,33 @@
             // REMOVED JavaScript hover listeners for statsTab, inventoryTab, and infoTab
             // CSS :hover will now handle their visibility and animation.
 
-            if (actionsTab && actionsContent) {
-                actionsTab.addEventListener('click', () => {
-                    // For actionsContent, we toggle between 'none' and 'flex'
-                    // because #actions-content is a flex container itself.
-                    const isHidden = actionsContent.style.display === 'none' || actionsContent.style.display === '';
-                    actionsContent.style.display = isHidden ? 'flex' : 'none'; // Use 'flex'
-                    if (isHidden) {
-                        actionsTab.classList.add('actions-tab-active');
-                    } else {
-                        actionsTab.classList.remove('actions-tab-active');
-                    }
-                    // Note: The 'display: flex' for #actions-content when visible
-                    // was already specified in the CSS for #actions-content when it's active/shown.
-                    // The previous CSS had it as `display: flex` overriding `.tab-content display:none`.
-                    // Now, `.tab-content` no longer has `display:none`.
-                    // `#actions-content` specifically has `display:none` initially.
-                    // So JS must set it to `display:flex` to show it.
+            // Old listener for #actions-tab (the container) is removed.
+            // if (actionsTab && actionsContent) { ... }
+
+            // New listeners for Actions/Log tab buttons
+            if (actionsTabButton && actionsPanelContent && logTabButton && logPanelContent) {
+                actionsTabButton.addEventListener('click', () => {
+                    actionsPanelContent.classList.add('panel-visible');
+                    logPanelContent.classList.remove('panel-visible');
+                    actionsTabButton.classList.add('active-tab-button');
+                    logTabButton.classList.remove('active-tab-button');
                 });
+
+                logTabButton.addEventListener('click', () => {
+                    logPanelContent.classList.add('panel-visible');
+                    actionsPanelContent.classList.remove('panel-visible');
+                    logTabButton.classList.add('active-tab-button');
+                    actionsTabButton.classList.remove('active-tab-button');
+                });
+
+                // Initial state: Make Actions tab active by default
+                actionsTabButton.classList.add('active-tab-button');
+                actionsPanelContent.classList.add('panel-visible');
+                // Ensure log tab is not active/visible initially
+                logTabButton.classList.remove('active-tab-button');
+                logPanelContent.classList.remove('panel-visible');
             }
+
 
             if (topRightMenuButton && settingsPopup) {
                 topRightMenuButton.addEventListener('click', () => {


### PR DESCRIPTION
I separated the "Actions & Log" section into two distinct tabs: "Actions" and "Log". Clicking on each tab reveals its content panel with a sliding animation.

Key changes:
- Modified HTML to create new tab buttons and content panel wrappers.
- Updated CSS to style the tabs and panels, and to implement the sliding animation using max-height.
- Updated JavaScript to handle tab switching logic and set the "Actions" tab as active by default.

This change improves UI clarity by organizing actions and game logs into their own dedicated, expandable sections.