### PR TITLE
feat: Implement action result popup and ensure log integrity

### DIFF
--- a/shopkeeperPython/app.py
+++ b/shopkeeperPython/app.py
@@ -459,6 +459,8 @@ def display_game_output():
     global player_char
     global game_manager_instance
 
+    popup_action_result = session.pop('action_result', None) # Get and clear action result from session
+
     user_logged_in = 'username' in session
     # Initialize these to False. Their final values will be determined by the logic below.
     show_character_selection = False
@@ -636,7 +638,8 @@ def display_game_output():
                            available_towns=available_towns,
                            current_town_sub_locations_json=json.dumps(current_town_sub_locations),
                            all_towns_data_json=json.dumps(all_towns_data),
-                           available_recipes=available_recipes
+                           available_recipes=available_recipes,
+                           popup_action_result=popup_action_result # Pass to template
                            )
 
 def parse_action_details(details_str: str) -> dict:
@@ -761,6 +764,17 @@ def perform_action():
         import traceback
         game_manager_instance._print(f"Traceback: {traceback.format_exc()}")
 
+    # Capture action result for popup before redirecting
+    session['action_result'] = output_stream.getvalue()
+    # Clear the main output_stream AFTER capturing its value for the session,
+    # so it doesn't get displayed in the main log area on the next page load.
+    # However, the game_output for the next page load in display_game_output
+    # will re-fetch from output_stream.getvalue().
+    # This means the action result WILL appear in the main log as well.
+    # If the goal is to ONLY show it in the popup and NOT in the main log,
+    # then output_stream must be cleared here.
+    # output_stream.truncate(0) # Removed as per new requirement
+    # output_stream.seek(0) # Removed as per new requirement
 
     return redirect(url_for('display_game_output'))
 

--- a/shopkeeperPython/templates/index.html
+++ b/shopkeeperPython/templates/index.html
@@ -194,6 +194,34 @@
         .character-creation-container #stats_container span {
             flex-grow: 1;
         }
+
+        /* Action Result Popup Styles */
+        #action-result-popup {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background-color: white;
+            padding: 20px;
+            border: 1px solid #ccc;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            z-index: 1000;
+            display: none; /* Hidden by default */
+        }
+        #action-result-popup #close-popup-button {
+            display: block;
+            margin-top: 15px;
+            padding: 8px 15px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            float: right; /* Or use flexbox on a parent for better alignment */
+        }
+        #action-result-popup #close-popup-button:hover {
+            background-color: #0056b3;
+        }
     </style>
 </head>
 <body>
@@ -975,8 +1003,35 @@
                 }
             });
         }
+
+        // Action Result Popup Handling
+        const popupActionResult = {{ popup_action_result | tojson | safe }};
+        const actionResultPopup = document.getElementById('action-result-popup');
+        const actionResultMessage = document.getElementById('action-result-message');
+        const closePopupButton = document.getElementById('close-popup-button');
+
+        if (popupActionResult && popupActionResult.trim() !== "") {
+            if (actionResultMessage) {
+                // Replace newline characters with <br> tags for HTML display
+                actionResultMessage.innerHTML = popupActionResult.replace(/\n/g, '<br>');
+            }
+            if (actionResultPopup) {
+                actionResultPopup.style.display = 'block';
+            }
+        }
+
+        if (closePopupButton && actionResultPopup) {
+            closePopupButton.addEventListener('click', function() {
+                actionResultPopup.style.display = 'none';
+            });
+        }
     });
     </script>
     {% endif %}
+
+    <div id="action-result-popup" style="display: none;">
+        <div id="action-result-message"></div>
+        <button id="close-popup-button">Close</button>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Adds a modal popup to display the immediate result of a player's action. This provides instant feedback to you without needing to switch to the log tab.

Changes include:
- Added HTML structure and CSS for the popup in `templates/index.html`.
- Modified `app.py` to use the Flask session to pass the last action's result to the template for popup display.
- Added JavaScript in `templates/index.html` to show the popup when an action result is available and to handle its closing.
- Ensured that the main game log in the 'Log' tab continues to correctly record all action messages, including those shown in the popup.