### PR TITLE
Fix: Prevent sub-location action modal from closing prematurely

### DIFF
--- a/shopkeeperPython/static/style.css
+++ b/shopkeeperPython/static/style.css
@@ -595,3 +595,96 @@ body {
 /* The specific #stats-tab, #inventory-tab, #actions-tab fixed px widths from older versions are removed */
 /* The multiple html, body definitions are consolidated at the top */
 /* The multiple .game-container definitions are consolidated */
+
+/* Modal styles - Transferred and Refined */
+.modal { /* Targets #subLocationActionsModal */
+    display: none; /* Hidden by default */
+    position: fixed; /* Stay in place */
+    z-index: 1050; /* Higher than most elements, adjust if needed (e.g. Bootstrap modals are often 1050) */
+    left: 0;
+    top: 0;
+    width: 100%; /* Full width */
+    height: 100%; /* Full height */
+    overflow: auto; /* Enable scroll if modal content is too long */
+    background-color: rgba(0,0,0,0.5); /* Slightly darker backdrop */
+}
+
+.modal-content { /* Class for the content area of the modal */
+    background-color: #fefefe;
+    /* margin: 15% auto; /* Replaced with transform for better centering */
+    position: fixed; /* Changed to fixed for transform centering */
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    padding: 25px; /* Increased padding */
+    border: 1px solid #888;
+    border-radius: 8px; /* Added border-radius */
+    width: 90%; /* Responsive width */
+    max-width: 450px; /* Slightly increased max-width */
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3); /* Enhanced box-shadow */
+}
+
+.modal-content h3 { /* Styling for heading within modal */
+    margin-top: 0;
+    margin-bottom: 15px;
+    font-size: 1.5em;
+    color: #333;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 10px;
+}
+
+.close-button { /* For the 'X' button */
+    color: #555; /* Darker for better visibility */
+    position: absolute; /* Position relative to modal-content */
+    top: 10px; /* Adjusted position */
+    right: 15px; /* Adjusted position */
+    font-size: 32px; /* Larger size */
+    font-weight: bold;
+    line-height: 1; /* Ensure proper vertical alignment */
+}
+
+.close-button:hover,
+.close-button:focus {
+    color: #000; /* Black on hover/focus */
+    text-decoration: none;
+    cursor: pointer;
+}
+
+#modal-actions-list {
+    margin-top: 15px; /* Space above the buttons list */
+    display: flex;
+    flex-direction: column;
+    gap: 12px; /* Space between action buttons */
+}
+
+#modal-actions-list ul { /* If an UL is still used, though direct buttons are more likely with flex */
+    list-style-type: none;
+    padding: 0;
+    margin: 0; /* Reset margin if UL is present */
+    display: flex;
+    flex-direction: column;
+    gap: 12px; /* Space between li elements if ul is used */
+}
+
+#modal-actions-list li { /* If an LI is still used */
+    margin-bottom: 0; /* Handled by gap in parent (ul or #modal-actions-list) */
+}
+
+/* Styling for buttons specifically within the modal, using .action-button class */
+/* This ensures consistency if .action-button is used elsewhere but needs specific modal styling */
+.modal #modal-actions-list .action-button {
+    width: 100%;
+    padding: 12px 15px; /* Generous padding */
+    background-color: #007bff; /* Primary blue */
+    color: white;
+    border: none;
+    border-radius: 5px; /* Slightly more rounded */
+    cursor: pointer;
+    font-size: 1em; /* Clear font size */
+    text-align: center;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.modal #modal-actions-list .action-button:hover {
+    background-color: #0056b3; /* Darker blue on hover */
+}

--- a/shopkeeperPython/templates/index.html
+++ b/shopkeeperPython/templates/index.html
@@ -672,8 +672,15 @@
 
             const mapDestinationsDiv = document.getElementById('map-destinations');
             const subLocationsListDiv = document.getElementById('sub-locations-list');
-            const currentActionsListDiv = document.getElementById('current-actions-list');
+            // const currentActionsListDiv = document.getElementById('current-actions-list'); // No longer primary target for displayActions
+            let currentActionsListDiv = document.getElementById('current-actions-list'); // Keep for event listener for now
             const currentTownDisplay = document.getElementById('current-town-display');
+
+            // Modal elements
+            const subLocationActionsModal = document.getElementById('subLocationActionsModal');
+            const modalActionsListDiv = document.getElementById('modal-actions-list');
+            const modalCloseButton = subLocationActionsModal ? subLocationActionsModal.querySelector('.close-button') : null;
+
 
             // Action Detail Divs and Inputs
             const actionDetailsContainer = document.getElementById('action-details-container');
@@ -725,8 +732,13 @@
 
             // Function to display actions for a selected sub-location
             function displayActions(subLocName) {
-                if (!currentActionsListDiv) return;
-                currentActionsListDiv.innerHTML = ''; // Clear previous
+                // if (!currentActionsListDiv) return; // Old target
+                // currentActionsListDiv.innerHTML = ''; // Clear previous
+                if (!modalActionsListDiv || !subLocationActionsModal) {
+                    console.error("Modal elements not found for displayActions");
+                    return;
+                }
+                modalActionsListDiv.innerHTML = ''; // Clear previous modal actions
                 currentSubLocationName = subLocName; // Store the sub-location name
 
                 const currentTownName = currentTownDisplay ? currentTownDisplay.textContent : null;
@@ -744,16 +756,43 @@
                     selectedSubLocation.actions.forEach(actionStr => {
                         const li = document.createElement('li');
                         const button = document.createElement('button');
-                        button.className = 'action-button';
+                        button.className = 'action-button'; // Keep class for existing event listeners
                         button.dataset.actionName = actionStr;
                         button.textContent = actionStr.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()); // Prettify
                         li.appendChild(button);
                         ul.appendChild(li);
                     });
-                    currentActionsListDiv.appendChild(ul);
+                    modalActionsListDiv.appendChild(ul);
+                    subLocationActionsModal.style.display = 'block'; // Show modal
                 } else {
-                    currentActionsListDiv.innerHTML = '<p>No actions available here.</p>';
+                    modalActionsListDiv.innerHTML = '<p>No actions available here.</p>';
+                    subLocationActionsModal.style.display = 'block'; // Show modal even if no actions, to indicate it was opened
                 }
+            }
+
+            // Modal Close Functionality
+            if (modalCloseButton) {
+                modalCloseButton.addEventListener('click', function() {
+                    if (subLocationActionsModal) subLocationActionsModal.style.display = 'none';
+                });
+            }
+
+            if (subLocationActionsModal) {
+                // REMOVED:
+                // window.addEventListener('click', function(event) {
+                //     if (event.target == subLocationActionsModal) { // Clicked outside of the modal content
+                //         subLocationActionsModal.style.display = 'none';
+                //     }
+                // });
+
+                // ADDED:
+                subLocationActionsModal.addEventListener('click', function(event) {
+                    // If the click is directly on the modal backdrop (event.target is the modal itself)
+                    // then close the modal.
+                    if (event.target === subLocationActionsModal) {
+                        subLocationActionsModal.style.display = 'none';
+                    }
+                });
             }
 
             // Event Listener for Map Destination Buttons
@@ -778,11 +817,25 @@
                 });
             }
 
-            // Event Listener for Action Buttons (from current-actions-list)
-            if (currentActionsListDiv) {
-                currentActionsListDiv.addEventListener('click', function(event) {
-                    if (event.target.classList.contains('action-button')) {
-                        const actionName = event.target.dataset.actionName;
+            // Event Listener for Action Buttons (now potentially inside modal or other containers)
+            // This listener should be attached to a static parent that exists at load time,
+            // or re-evaluate if currentActionsListDiv is still the correct parent for all actions.
+            // For now, we assume action buttons are still eventually handled if they bubble up
+            // or if the modal's content is part of a structure listened to by 'currentActionsListDiv's parent.
+            // Let's refine this: if actions are ONLY in the modal, this listener needs to be on modalActionsListDiv or its parent.
+            // However, the original setup might have used event delegation on a higher-up container.
+            // The most robust change is to make the listener target the modal if that's where buttons are now.
+            // For the subtask, the buttons are moved to `modal-actions-list`.
+            // So, the listener for these specific buttons should be on `modalActionsListDiv`.
+            // The old `currentActionsListDiv` might still be used for other things or might become obsolete for this.
+
+            const actionButtonClickHandler = function(event) {
+                if (event.target.classList.contains('action-button')) {
+                    const actionName = event.target.dataset.actionName;
+                    // Hide the modal if an action button inside it is clicked
+                    if (subLocationActionsModal && subLocationActionsModal.contains(event.target)) {
+                        subLocationActionsModal.style.display = 'none';
+                    }
                         hideAllDetailForms(); // Hide any open detail forms first
                         currentActionRequiringDetails = null; // Reset
 
@@ -840,8 +893,24 @@
                             if (actionForm) actionForm.submit();
                         }
                     }
-                });
+            };
+
+            // Attach the handler to the modal list for actions populated by displayActions
+            if (modalActionsListDiv) {
+                modalActionsListDiv.addEventListener('click', actionButtonClickHandler);
             }
+
+            // If currentActionsListDiv is still used for other buttons (e.g. not from displayActions),
+            // it needs its own listener or a shared one if they are in a common parent.
+            // For now, assuming actions from displayActions are the primary concern for the modal.
+            // If currentActionsListDiv was only for sub-location actions, it might not need a listener anymore
+            // if all sub-location actions now go to the modal.
+            // Let's keep its original listener for now, in case it handles other dynamically added buttons
+            // that are NOT part of sub-location actions.
+             if (currentActionsListDiv) {
+                currentActionsListDiv.addEventListener('click', actionButtonClickHandler);
+             }
+
 
             // Event Listener for the new Craft Recipe Buttons
             const craftingRecipesList = document.getElementById('crafting-recipes-list');
@@ -1112,6 +1181,16 @@
     <div id="action-result-popup" style="display: none;">
         <div id="action-result-message"></div>
         <button id="close-popup-button">Close</button>
+    </div>
+
+    <div id="subLocationActionsModal" class="modal">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <h3>Actions</h3>
+            <div id="modal-actions-list">
+                <!-- Action buttons will be dynamically inserted here -->
+            </div>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Your feedback indicated that the modal for sub-location actions was flashing on the screen and disappearing immediately. This was likely due to the click event that opened the modal also being processed by the global 'click outside' listener in a way that caused it to close.

This commit refines the modal's closing behavior:
- The event listener for closing the modal by clicking its backdrop is now attached directly to the modal element (`subLocationActionsModal`) instead of the `window` object.
- The listener now closes the modal only if the click target is exactly the modal backdrop itself (`event.target === subLocationActionsModal`).

This change ensures that the modal remains open when a sub-location button is clicked and only closes when you explicitly click the backdrop, the 'X' close button, or an action button within the modal.