### PR TITLE
Add debug prints for time advancement

### DIFF
--- a/shopkeeperPython/game/game_manager.py
+++ b/shopkeeperPython/game/game_manager.py
@@ -673,10 +673,19 @@ class GameManager:
         if self.character.is_dead and time_advanced_by_action_hours == 0:
             hours_to_advance = 1 # Ensure time passes if dead, even if action didn't specify hours
 
+        self._print(f"  DEBUG: Time Advancement for action '{action_name}':")
+        self._print(f"    - Initial time_advanced_by_action_hours: {time_advanced_by_action_hours}")
+        self._print(f"    - Calculated hours_to_advance: {hours_to_advance}")
+        self._print(f"    - Time before advance_hour: {self.time.get_time_string()}")
+
         day_before_advancing_time = self.time.current_day
         self.time.advance_hour(hours_to_advance)
+
+        self._print(f"    - Time after advance_hour: {self.time.get_time_string()}")
+
         # End of day summary check also moved up, if time advancement causes day to change.
         if self.time.current_day != day_before_advancing_time and self.tracking_day == day_before_advancing_time:
+            self._print(f"  DEBUG: Day changed. Running end of day summary for day {self.tracking_day}.")
             self._run_end_of_day_summary(self.tracking_day)
 
         # --- Event System (Post Time-Advancement) ---

--- a/shopkeeperPython/game/time_system.py
+++ b/shopkeeperPython/game/time_system.py
@@ -25,11 +25,14 @@ class GameTime:
         Returns:
             tuple[int, int]: A tuple containing (days_passed, new_current_hour).
         """
+        print(f"  DEBUG GameTime.advance_hour: Start. Current: Day {self.current_day}, {self.current_hour:02d}:00. Advancing by {hours} hour(s).")
+
         if hours < 0:
-            # print("Cannot advance time by a negative number of hours.") # Less verbose
+            print("  DEBUG GameTime.advance_hour: Cannot advance time by a negative number of hours.")
             return 0, self.current_hour
 
         if hours == 0:
+            print("  DEBUG GameTime.advance_hour: Advancing by 0 hours, no change.")
             return 0, self.current_hour
 
         days_passed = 0
@@ -39,8 +42,10 @@ class GameTime:
             self.current_hour -= 24
             self.current_day += 1
             days_passed += 1
+            # This print is already useful:
             print(f"A new day has begun! It is now Day {self.current_day}.")
 
+        print(f"  DEBUG GameTime.advance_hour: End. New time: Day {self.current_day}, {self.current_hour:02d}:00. Days passed this call: {days_passed}.")
         return days_passed, self.current_hour
 
     def get_time_string(self) -> str:


### PR DESCRIPTION
- Added detailed debug prints in GameManager.perform_hourly_action around the call to GameTime.advance_hour to trace parameters and time before/after.
- Added detailed debug prints in GameTime.advance_hour to trace its internal processing of hours and day updates.

These prints are intended to diagnose why game time is not updating correctly for the 'Gather Resources' action.