### PR TITLE
Feat: Implement persistence for game time

### DIFF
--- a/shopkeeperPython/app.py
+++ b/shopkeeperPython/app.py
@@ -1086,7 +1086,11 @@ def perform_action():
             if username and slot_index is not None:
                 if username in user_characters and 0 <= slot_index < len(user_characters[username]):
                     current_town_name_to_save = g.game_manager.current_town.name if g.game_manager.current_town else "Unknown"
-                    user_characters[username][slot_index] = g.player_char.to_dict(current_town_name=current_town_name_to_save)
+                    current_time_dict = g.game_manager.time.to_dict()
+                    user_characters[username][slot_index] = g.player_char.to_dict(
+                        current_town_name=current_town_name_to_save,
+                        current_time_data=current_time_dict
+                    )
                     save_user_characters() # Global save function is fine
                 else:
                     g.game_manager._print(f"  Warning: Character slot data mismatch for user {username}, slot {slot_index}. Could not save character state after action.")
@@ -1119,7 +1123,11 @@ def perform_action():
                 )
                 if username and slot_index is not None and user_characters.get(username) and 0 <= slot_index < len(user_characters[username]):
                     current_town_name_death_save = g.game_manager.current_town.name if g.game_manager.current_town else "Unknown"
-                    user_characters[username][slot_index] = g.player_char.to_dict(current_town_name=current_town_name_death_save)
+                    current_time_dict_death_save = g.game_manager.time.to_dict()
+                    user_characters[username][slot_index] = g.player_char.to_dict(
+                        current_town_name=current_town_name_death_save,
+                        current_time_data=current_time_dict_death_save
+                    )
                     save_user_characters()
 
             if username and slot_index is not None:
@@ -1222,7 +1230,11 @@ def submit_event_choice_route():
         slot_idx = session.get('selected_character_slot')
         if username and slot_idx is not None and username in user_characters and 0 <= slot_idx < len(user_characters[username]):
             current_town_name_event_save = g.game_manager.current_town.name if g.game_manager.current_town else "Unknown"
-            user_characters[username][slot_idx] = g.player_char.to_dict(current_town_name=current_town_name_event_save)
+            current_time_dict_event_save = g.game_manager.time.to_dict()
+            user_characters[username][slot_idx] = g.player_char.to_dict(
+                current_town_name=current_town_name_event_save,
+                current_time_data=current_time_dict_event_save
+            )
             save_user_characters()
         else:
             g.game_manager._print("  Warning: Could not save character state after event due to session/slot mismatch.")

--- a/shopkeeperPython/game/character.py
+++ b/shopkeeperPython/game/character.py
@@ -762,6 +762,44 @@ class Character:
         char._recalculate_all_attributes() # Recalculate attributes after loading all data
         return char
 
+    def to_dict(self, current_town_name: str = None, current_time_data: dict = None) -> dict:
+        # If current_town_name is None, default to "Starting Village"
+        town_name_to_save = current_town_name if current_town_name is not None else "Starting Village"
+        data = {
+            "name": self.name,
+            "stats": self.stats.copy(),
+            "stat_bonuses": self.stat_bonuses.copy(), # Item stat bonuses
+            "ac_bonus": self.ac_bonus,
+            "level": self.level,
+            "xp": self.xp,
+            "pending_xp": self.pending_xp,
+            "base_max_hp": self.base_max_hp,
+            "hp": self.hp,
+            "hit_dice": self.hit_dice,
+            "max_hit_dice": self.max_hit_dice,
+            "attunement_slots": self.attunement_slots,
+            "attuned_items": [item.to_dict() for item in self.attuned_items],
+            "exhaustion_level": self.exhaustion_level,
+            "inventory": [item.to_dict() for item in self.inventory],
+            "gold": self.gold,
+            "skill_points_to_allocate": self.skill_points_to_allocate,
+            "speed": self.speed,
+            "is_dead": self.is_dead,
+            "current_town_name": town_name_to_save,
+            "journal": [entry.to_dict() for entry in self.journal],
+            "background_id": self.background_id,
+            "appearance_data": self.appearance_data,
+            "attribute_bonuses_from_background": self.attribute_bonuses_from_background,
+            "feats": self.feats,
+            "feat_attribute_bonuses": self.feat_attribute_bonuses,
+            "feat_stat_bonuses": self.feat_stat_bonuses,
+            "faction_reputations": self.faction_reputations,
+            "pending_asi_feat_choice": self.pending_asi_feat_choice,
+        }
+        if current_time_data is not None:
+            data["game_time_snapshot"] = current_time_data
+        return data
+
     # --- Attribute Calculation Methods ---
     def _calculate_attribute_score(self, attribute_name: str) -> int:
         """
@@ -921,10 +959,10 @@ class Character:
         """Checks if the character has a specific feat."""
         return feat_id in self.feats
 
-    def to_dict(self, current_town_name: str = None) -> dict:
+    def to_dict(self, current_town_name: str = None, current_time_data: dict = None) -> dict:
         # If current_town_name is None, default to "Starting Village"
         town_name_to_save = current_town_name if current_town_name is not None else "Starting Village"
-        return {
+        data = {
             "name": self.name,
             "stats": self.stats.copy(),
             "stat_bonuses": self.stat_bonuses.copy(), # Item stat bonuses
@@ -937,7 +975,7 @@ class Character:
             "hit_dice": self.hit_dice,
             "max_hit_dice": self.max_hit_dice,
             "attunement_slots": self.attunement_slots,
-            "attuned_items": [item.to_dict() for item in self.attuned_items], # Corrected key
+            "attuned_items": [item.to_dict() for item in self.attuned_items],
             "exhaustion_level": self.exhaustion_level,
             "inventory": [item.to_dict() for item in self.inventory],
             "gold": self.gold,
@@ -955,6 +993,9 @@ class Character:
             "faction_reputations": self.faction_reputations,
             "pending_asi_feat_choice": self.pending_asi_feat_choice,
         }
+        if current_time_data is not None:
+            data["game_time_snapshot"] = current_time_data
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> 'Character':
@@ -998,6 +1039,9 @@ class Character:
         # are already correctly stored in base_max_hp, feat_attribute_bonuses, and feat_stat_bonuses respectively.
         # This is important to prevent issues like double-adding HP bonuses.
         char.pending_asi_feat_choice = data.get("pending_asi_feat_choice", False)
+
+        # Load game time snapshot
+        char.loaded_game_time_data = data.get("game_time_snapshot", None) # Store it on the character instance
 
         journal_data = data.get("journal", [])
         if journal_data:

--- a/shopkeeperPython/game/game_manager.py
+++ b/shopkeeperPython/game/game_manager.py
@@ -104,10 +104,16 @@ class GameManager:
         self.output_stream = output_stream
         self._print("Initializing GameManager (basic)...")
 
-        self.time = GameTime()
-        self._print(f"Game time started at {self.time.get_time_string()}.")
-
         self.character = player_character if player_character else Character(name=None)
+
+        # Initialize GameTime: Use loaded time from character if available, else default.
+        if self.character and hasattr(self.character, 'loaded_game_time_data') and self.character.loaded_game_time_data:
+            self.time = GameTime.from_dict(self.character.loaded_game_time_data)
+            self._print(f"Game time loaded from character snapshot: {self.time.get_time_string()}.")
+        else:
+            self.time = GameTime()
+            self._print(f"Game time started at default: {self.time.get_time_string()}.")
+
         if self.character and self.character.name:
             self._print(f"Initial character reference: {self.character.name}")
         else:


### PR DESCRIPTION
- Modified Character.to_dict to accept and store current_time_data.
- Modified Character.from_dict to load game_time_snapshot.
- Modified GameManager.__init__ to initialize its GameTime object from the character's loaded_game_time_data, if available, defaulting to a new GameTime instance otherwise.
- Updated app.py to pass the current game time from g.game_manager.time.to_dict() when saving character data in perform_action and submit_event_choice_route.

This ensures that game time is saved with the character and reloaded across requests, allowing the UI to display the correct, advancing game time.