### PR TITLE
Feat: Move location and sub-location actions to map area

### DIFF
--- a/shopkeeperPython/static/style.css
+++ b/shopkeeperPython/static/style.css
@@ -146,15 +146,43 @@ body {
 #map-container {
     grid-area: map;
     display: flex;
-    align-items: center;
-    justify-content: center;
+    flex-direction: column; /* Allow SVG and new container to stack */
+    align-items: center; /* Center items horizontally */
+    justify-content: flex-start; /* Align items to the top */
     padding: 10px;
     background-color: var(--color-parchment-bg);
     border: 1px solid var(--color-light-border);
     border-radius: 4px;
-    overflow: hidden;
+    overflow-y: auto; /* Allow scrolling if content overflows */
 }
-#map-container svg { width: 100%; height: 100%; object-fit: contain; }
+#map-container svg {
+    width: 100%;
+    height: 300px; /* Give SVG a fixed height for now */
+    object-fit: contain;
+    flex-shrink: 0; /* Prevent SVG from shrinking if space is tight */
+    margin-bottom: 15px; /* Space below the SVG */
+}
+
+/* Style for the moved location interactions container */
+#map-container #location-interactions-container {
+    width: 100%; /* Take full width of the map-container */
+    margin-top: 10px; /* Add some space above it if SVG margin-bottom isn't enough */
+    background-color: var(--color-aged-paper); /* Keep its distinct background */
+    border: 1px solid var(--color-deep-brown-border); /* A slightly more prominent border */
+    box-shadow: 0 2px 4px rgba(0,0,0,0.15); /* A bit more shadow to lift it */
+}
+
+#map-container #location-interactions-container h4,
+#map-container #location-interactions-container h5 {
+    /* Styles for headings inside the moved container, if they need adjustment */
+    /* For now, they inherit from .action-section which should be fine */
+}
+
+#map-container #location-interactions-container .button-list {
+    /* Styles for button lists inside the moved container */
+    justify-content: center; /* Center buttons in the list */
+}
+
 
 #right-inventory-column {
     grid-area: right-col;

--- a/shopkeeperPython/templates/index.html
+++ b/shopkeeperPython/templates/index.html
@@ -259,6 +259,18 @@
               <rect width="100%" height="100%" fill="#cccccc"></rect>
               <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="24px" fill="#333333">Overworld Map</text>
             </svg>
+            <div id="location-interactions-container" class="action-section">
+                <h4>Current Location: <span id="current-town-display-actions">{{ current_town_name }}</span></h4>
+                <div id="sub-locations-list" class="button-list">
+                    <!-- JS populates sub-location buttons -->
+                </div>
+                <div id="current-sub-location-actions-container">
+                    <h5 id="current-sub-location-name-display" style="display:none;"></h5>
+                    <div id="current-sub-location-actions-list" class="button-list">
+                        <!-- JS populates actions for a selected sub-location -->
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- Right Inventory Column -->
@@ -337,18 +349,7 @@
                                 </div>
                             </div>
 
-                            <div id="location-interactions-container" class="action-section">
-                                <h4>Current Location: <span id="current-town-display-actions">{{ current_town_name }}</span></h4>
-                                <div id="sub-locations-list" class="button-list">
-                                    <!-- JS populates sub-location buttons -->
-                                </div>
-                                <div id="current-sub-location-actions-container">
-                                    <h5 id="current-sub-location-name-display" style="display:none;"></h5>
-                                    <div id="current-sub-location-actions-list" class="button-list">
-                                        <!-- JS populates actions for a selected sub-location -->
-                                    </div>
-                                </div>
-                            </div>
+                            <!-- MOVED to map-container: location-interactions-container -->
 
                             <div id="general-actions-container" class="action-section">
                                 <h4>General</h4>


### PR DESCRIPTION
Relocates the 'Current Location', sub-location buttons, and sub-location action buttons from the 'Actions' tab in the bottom bar to the main 'Overworld Map' container.

- Modifies index.html to move the relevant div.
- Adjusts style.css to ensure the moved elements are displayed as a functional placeholder within the map container.
- JavaScript functionality for these buttons is maintained as element IDs were preserved.

This change is a preliminary step towards overlaying these interactive elements on map artwork in the future.