### PR TITLE
Fix: Prevent trade error modal on new character screen

### DIFF
--- a/shopkeeperPython/app.py
+++ b/shopkeeperPython/app.py
@@ -875,6 +875,13 @@ def display_game_output():
         "max_shop_level": Shop.MAX_SHOP_LEVEL
     }
 
+    haggling_data_for_template = g.game_manager.active_haggling_session if g.game_manager else None
+
+    # SAFEGUARD: Ensure active_haggling_session is either None or a dictionary
+    if haggling_data_for_template is not None and not isinstance(haggling_data_for_template, dict):
+        app.logger.warning(f"CRITICAL WARNING: active_haggling_session was not None and not a dict. Type: {type(haggling_data_for_template)}, Value: {haggling_data_for_template}. Forcing to None for template.")
+        haggling_data_for_template = None
+
     return render_template('index.html',
                            user_logged_in=user_logged_in,
                            show_character_selection=show_character_selection,
@@ -917,7 +924,10 @@ def display_game_output():
                            # ASI/Feat Choice Data for JS
                            player_pending_asi_feat_choice=player_pending_asi_feat_choice_display,
                            feat_definitions_json=json.dumps(feat_definitions_for_template),
-                           player_stats_json=json.dumps(player_stats_for_template)
+                           player_stats_json=json.dumps(player_stats_for_template),
+                           # Haggling data passed to template
+                           haggling_pending=bool(haggling_data_for_template),
+                           pending_haggling_data_json=json.dumps(haggling_data_for_template) if haggling_data_for_template else None
                            )
 
 # --- Reroll Stat Route ---


### PR DESCRIPTION
The trade error modal was appearing incorrectly for new characters due to potentially invalid haggling session data being passed to the JavaScript frontend.

This commit implements a two-fold fix:
1.  JavaScript Enhancement: Modified UIHaggling.populateAndShowModal in main_ui.js to more robustly handle invalid or empty haggling data. If such data is received, it now displays a generic "Trade Unavailable" message and ensures only the decline/close button is active, rather than showing "Error (N/A)" fields.
2.  Python Safeguard: Added a check in the display_game_output route in app.py. If game_manager.active_haggling_session is not None and not a dictionary, it's forced to None before being passed to the template. This prevents malformed data from reaching the JS.

These changes ensure the UI remains stable and provides clearer feedback if unexpected haggling data states occur, and primarily prevents the error from appearing for new characters.