### PR TITLE
Add debug logging for haggling data in app.py

### DIFF
--- a/shopkeeperPython/app.py
+++ b/shopkeeperPython/app.py
@@ -882,6 +882,13 @@ def display_game_output():
         app.logger.warning(f"CRITICAL WARNING: active_haggling_session was not None and not a dict. Type: {type(haggling_data_for_template)}, Value: {haggling_data_for_template}. Forcing to None for template.")
         haggling_data_for_template = None
 
+    # --- Temporary Debugging for Haggling ---
+    app.logger.info(f"DEBUG_DISPLAY_OUTPUT: g.game_manager.active_haggling_session = {g.game_manager.active_haggling_session if hasattr(g, 'game_manager') and g.game_manager else 'GM_NOT_AVAILABLE'}")
+    temp_haggling_pending = bool(haggling_data_for_template)
+    temp_pending_haggling_json = json.dumps(haggling_data_for_template) if haggling_data_for_template else None
+    app.logger.info(f"DEBUG_DISPLAY_OUTPUT: Values for template -> haggling_pending: {temp_haggling_pending}, pending_haggling_data_json: {temp_pending_haggling_json}")
+    # --- End Temporary Debugging ---
+
     return render_template('index.html',
                            user_logged_in=user_logged_in,
                            show_character_selection=show_character_selection,


### PR DESCRIPTION
Added temporary logging in the display_game_output route in app.py to print the state of g.game_manager.active_haggling_session and the values being passed to the template for haggling_pending and pending_haggling_data_json. This is to help diagnose why the haggling modal might not be appearing despite backend logic seeming correct.