### PR TITLE
Call UIHaggling.init in main function

### DIFF
--- a/shopkeeperPython/static/js/main_ui.js
+++ b/shopkeeperPython/static/js/main_ui.js
@@ -1671,6 +1671,7 @@ function main() {
     UITopMenu.init();
     UISkillAllocation.init();
     UIAsiFeatChoice.init(); // Initialize ASI/Feat choice UI
+    UIHaggling.init(); // Initialize Haggling UI event listeners
 
     if (DOM.actionForm) { // Core game interactions are available
         UIActionsAndEvents.init();


### PR DESCRIPTION
Added UIHaggling.init() to the main() function in main_ui.js. This ensures that the event listeners for the haggling modal buttons are attached during page initialization, which should fix the issue of the buttons being unresponsive.