### PR TITLE
Fix: Resolve UnboundLocalError for shop_inventory_full_data

### DIFF
--- a/shopkeeperPython/app.py
+++ b/shopkeeperPython/app.py
@@ -621,6 +621,7 @@ def display_game_output():
     dead_characters_info = []
     character_creation_stats_display = None
     pending_char_name_display = None
+    shop_inventory_full_data_for_template = [] # Initialize here
 
     # available_towns will be derived from g.game_manager later
     available_towns = list(g.game_manager.towns_map.keys()) if g.game_manager else []


### PR DESCRIPTION
Initialize `shop_inventory_full_data_for_template` to an empty list at the beginning of the `display_game_output` function in `shopkeeperPython/app.py`.

This ensures the variable is always defined before being passed to `render_template`, preventing an `UnboundLocalError` that occurred when no character was loaded or selected (e.g., on the login or character creation pages).