### PR TITLE
Fix: Correct syntax error in main_ui.js CONSTANTS definition

### DIFF
--- a/shopkeeperPython/static/js/main_ui.js
+++ b/shopkeeperPython/static/js/main_ui.js
@@ -29,7 +29,7 @@ const CONSTANTS = {
         HEMLOCK_HUT: "Old Man Hemlock's Hut",
         BORIN_SMITHY: "Borin Stonebeard's Smithy",
     }
-// Removed extraneous closing bracket and semicolon
+}; // Added missing closing brace and semicolon
 
 const UIAsiFeatChoice = {
     selectedMainChoice: null, // 'asi' or 'feat'


### PR DESCRIPTION
The CONSTANTS object literal was missing its closing curly brace and semicolon, causing a JavaScript parsing error when the next `const` keyword was encountered.

This change adds the required `};` to properly terminate the object definition.